### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,3 +7,12 @@ License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Depends:
+    R (>= 4.3.0)
+Imports:
+    Seurat,
+    SeuratObject,
+    data.table
+Collate: 
+    'SpectraWrapper.R'
+VignetteBuilder: knitr


### PR DESCRIPTION
Despite https://github.com/GWMcElfresh/SpectraWrapper/blob/44bb267894fb83e4a9e38d1e3aa8465e09d92904/Dockerfile#L35
Seurat doesn't end up installed in the docker image. 

This is a shot in the dark, but potentially when I pivoted repo to an R package, the build action changed somehow. 